### PR TITLE
fix: fix wandb project, change wandb name

### DIFF
--- a/ultralytics/train.py
+++ b/ultralytics/train.py
@@ -32,8 +32,8 @@ def main(args):
     if not data_dir :
         raise ValueError("Path not found in YAML file")
     
-    wb.init(project=cfg.get('project') if not None else 'YOLOv8',
-               name=cfg.get('model')[:-3] + '_' + str(cfg.get('batch')) + '_' + data_dir,
+    wb.init(project=cfg.get('project') or 'YOLOv8',
+               name=cfg.get('model')[:-3] + '_' + str(cfg.get('batch')) + '_' + data_dir + '_' + cfg.get('name') + '_' + 'epochs' + str(cfg.get('epochs')),
                entity='ai_tech_level2_objectdetection',
                mode=args.wandbmode)
 


### PR DESCRIPTION
## Overview
- wandb project default가 로깅 시 적용 안됨
- wandb logging된 job 구분을 위해 job name 변경 필요

## Change Log
- custom.yaml의 project를 기입하지 않으면 'YOLOv8' 프로젝트로 wandb logging 가능하도록 수정했습니다.
- wandb에 logging되는 job name을 기존 {Model_BatchSize_Dataset}에서 {Model_BatchSize_Dataset_Kfold_Seed_Epochs}로 변경했습니다.

## To Reviewer
- name 설정을 위해 custom.yaml의 name을 kfold(num)_seed(num)로 명명해주세요. (ex. name: kfold1_seed137)

## Issue Tags
- Closed: #16 